### PR TITLE
Truncated file size should be file.Truncate's argument

### DIFF
--- a/filesystem/truncate.go
+++ b/filesystem/truncate.go
@@ -51,7 +51,7 @@ func (truncator *FileTruncator) Remove() error {
 	for i := 0; i < truncateCount; i++ {
 		bar.Increment()
 		time.Sleep(truncator.TruncateInterval)
-		file.Truncate(truncator.TruncateUnit)
+		file.Truncate(truncator.FileSize - int64(i)*truncator.TruncateUnit)
 		file.Sync()
 	}
 	bar.FinishPrint("Removed " + truncator.FilePath)


### PR DESCRIPTION
## Summary

While using this tool, @ichirin2501 and I realized that the tool was _not_ actually deleting files slowly. I believe that this is due to the behavior of the `file.Truncate` function. This function accepts the file's final file size as the argument. But this tool's code provides the given `size` argument to the `file.Truncate` function directly.

### Bug

I confirmed the behavior of `file.Truncate` using this script:

```go
// file-truncate.go
package main

import "os"

func main() {
        fh, _ := os.OpenFile("1G", os.O_RDWR, 0)
        // Truncate to 1MB
        fh.Truncate(1024 * 1024 * 1)
        fh.Close()
}
```

```sh
# Create a 1GB file
$ ls -1sh 1G
1.0G 1G
$ stat 1G
  File: '1G'
  Size: 1073741824      Blocks: 2097152    IO Block: 4096   regular file
Device: ca01h/51713d    Inode: 536974701   Links: 1
Access: (0664/-rw-rw-r--)  Uid: ( 1665/siddharth)   Gid: ( 1665/siddharth)
Access: 2021-11-09 06:07:28.309855711 +0000
Modify: 2021-11-09 06:07:32.417819862 +0000
Change: 2021-11-09 06:07:32.417819862 +0000
 Birth: -

# Truncate that file using the above script
$ go run file-truncate.go

# Check the file's current size
$ ls -1sh 1G
1.0M 1G
$ stat 1G
  File: '1G'
  Size: 1048576         Blocks: 2048       IO Block: 4096   regular file
Device: ca01h/51713d    Inode: 536974701   Links: 1
Access: (0664/-rw-rw-r--)  Uid: ( 1665/siddharth)   Gid: ( 1665/siddharth)
Access: 2021-11-09 06:07:28.309855711 +0000
Modify: 2021-11-09 06:07:47.515687244 +0000
Change: 2021-11-09 06:07:47.515687244 +0000
 Birth: -
```

As can be seen above, the file's size reduced directly from 1GB => 1MB, instead of going from 1GB => 1GB-1MB as expected by this tool's code.

### With patch

After applying this patch, I watched the size of the file reduce slowly through `watch stat` and `watch ls -s` on local. I also confirmed this by running the script for 10 steps, then interrupting and confirming that the size of the file was as expected.

```sh
# Create a 1GB file full of zeroes
$ dd if=/dev/zero of=1G count=1024 ibs=1048576
1024+0 records in
2097152+0 records out
1073741824 bytes transferred in 8.553554 secs (125531658 bytes/sec)

# Check that file is 1 GB in size
$ ls -l 1G
-rw-r--r--  1 kannan.siddharth  staff  1073741824 Nov  9 11:45 1G

# Run go-remove-slowly for 10 steps
$ ./go-remove-slowly --interval 1s --size 10 1G
Removing File: 1G
 10 / 103 [=============>---------------------------------------------------------------------------------------------------------------------------------]   9.71% 01m26s^C

# Confirm that file size is about 900 MB (100 MB less than 1 GB = 1024 MB)
 $ ls -l 1G
-rw-r--r--  1 kannan.siddharth  staff  989855744 Nov  9 11:46 1G
```