### PR TITLE
Add an option to print simple output to STDOUT (instead of progress bar)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ dist: $@
 .PHONY: clean test build
 
 test: clean
-	@mkdir -p test /tmp/test_results cli/test/foo
+	@mkdir -p test /tmp/test_results cli/test/foo cli/test/bar
 	touch cli/test/file0 cli/test/foo/file1 cli/test/foo/file2
 	gotestsum --junitfile /tmp/test_results/unit-tests.xml -- -coverprofile=./test/coverage.out ./...
 	go tool cover -html=test/coverage.out -o test/coverage.html

--- a/cli/app.go
+++ b/cli/app.go
@@ -95,7 +95,7 @@ func NewApp() *MyApp {
 
 		for _, target := range targetFilePaths {
 			fmt.Fprintln(app.stream, "Removing File: "+target)
-			truncator := filesystem.NewFileTruncator(target, context.Duration("interval"), context.Int64("size"), app.stream)
+			truncator := filesystem.NewFileTruncator(target, context.Duration("interval"), context.Int64("size"), output.Type(context.String("output")), app.stream)
 			if err := truncator.Remove(); err != nil {
 				fmt.Fprintf(os.Stderr, "File %s removal error: %s\n", target, err.Error())
 				errs = append(errs, err)

--- a/cli/app.go
+++ b/cli/app.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/elastic-infra/go-remove-slowly/filesystem"
+	"github.com/elastic-infra/go-remove-slowly/output"
 	"github.com/urfave/cli/v2"
 )
 
@@ -121,6 +122,12 @@ func NewApp() *MyApp {
 			Name:    "quiet",
 			Aliases: []string{"q"},
 			Usage:   "When true, no output is written",
+		},
+		&cli.StringFlag{
+			Name:    "output",
+			Aliases: []string{"o"},
+			Usage:   "Select the type of output produced (Supported options: simple, progress-bar)",
+			Value:   output.Type_ProgressBar,
 		},
 		&cli.BoolFlag{
 			Name:    "version",

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -92,6 +92,27 @@ func TestAction_Version(t *testing.T) {
 	}
 }
 
+func TestSimpleOutput(t *testing.T) {
+	app := NewApp()
+	createFile("test/bar/file0", 4*1024*1024)
+	output := captureOutput(func() {
+		err := app.Run([]string{"cmd", "--output", "simple", "--size", "1", "test/bar/file0"})
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	})
+	t.Logf("Output: %s", output)
+	if !strings.Contains(output, "file: test/bar/file0") {
+		t.Fatalf("output must contain the name of the file which is being removed")
+	}
+	if !strings.Contains(output, "completion: 0.00%") {
+		t.Fatalf("output must contain 4 lines with each completion percentage ratio")
+	}
+	if !strings.Contains(output, "remaining: ") {
+		t.Fatalf("output must contain the remaining amount of time")
+	}
+}
+
 func createFile(path string, size int64) {
 	file, err := os.Create(path)
 	if err != nil {

--- a/filesystem/truncate.go
+++ b/filesystem/truncate.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/elastic-infra/go-remove-slowly/output"
 	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
@@ -22,14 +23,16 @@ type FileTruncator struct {
 	writer           io.Writer
 	TruncateUnit     int64
 	TruncateInterval time.Duration
+	OutputType       output.Type
 }
 
 // NewFileTruncator returns a new file truncator
-func NewFileTruncator(filePath string, interval time.Duration, sizeMB int64, writer io.Writer) *FileTruncator {
+func NewFileTruncator(filePath string, interval time.Duration, sizeMB int64, outputType output.Type, writer io.Writer) *FileTruncator {
 	truncator := &FileTruncator{
 		FilePath:         filePath,
 		TruncateUnit:     sizeMB * truncateSizeUnit,
 		TruncateInterval: interval,
+		OutputType:       outputType,
 		writer:           writer,
 	}
 	return truncator

--- a/filesystem/truncate_test.go
+++ b/filesystem/truncate_test.go
@@ -5,17 +5,19 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/elastic-infra/go-remove-slowly/output"
 )
 
 func TestNewFileTruncator(t *testing.T) {
-	truncator := NewFileTruncator("path", time.Duration(10), DefaultTruncateSizeMB, nil)
+	truncator := NewFileTruncator("path", time.Duration(10), DefaultTruncateSizeMB, output.Type_ProgressBar, nil)
 	if truncator.FilePath != "path" {
 		t.Fatalf("FilePath is incorrect")
 	}
 }
 
 func TestTruncateCount(t *testing.T) {
-	truncator := NewFileTruncator("path", time.Duration(10), DefaultTruncateSizeMB, nil)
+	truncator := NewFileTruncator("path", time.Duration(10), DefaultTruncateSizeMB, output.Type_ProgressBar, nil)
 	tests := []struct {
 		size  int64
 		count int
@@ -48,7 +50,7 @@ func TestUpdateStat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to write to the file %s", err.Error())
 	}
-	truncator := NewFileTruncator(path, time.Duration(1), DefaultTruncateSizeMB, nil)
+	truncator := NewFileTruncator(path, time.Duration(1), DefaultTruncateSizeMB, output.Type_ProgressBar, nil)
 	err = truncator.UpdateStat()
 	if err != nil {
 		t.Fatalf("UpdateStat failed: %s", err.Error())
@@ -60,7 +62,7 @@ func TestUpdateStat(t *testing.T) {
 
 func TestUpdateStat_PathError(t *testing.T) {
 	path := fmt.Sprintf("%s/%s", os.TempDir(), "statTestFile")
-	truncator := NewFileTruncator(path, time.Duration(1), DefaultTruncateSizeMB, nil)
+	truncator := NewFileTruncator(path, time.Duration(1), DefaultTruncateSizeMB, output.Type_ProgressBar, nil)
 	err := truncator.UpdateStat()
 	if err == nil {
 		t.Fatal("Error did not happen")
@@ -80,7 +82,7 @@ func TestRemove(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to write to the file %s", err.Error())
 	}
-	truncator := NewFileTruncator(path, time.Duration(1), DefaultTruncateSizeMB, nil)
+	truncator := NewFileTruncator(path, time.Duration(1), DefaultTruncateSizeMB, output.Type_ProgressBar, nil)
 	err = truncator.Remove()
 	if err != nil {
 		t.Fatalf("File Removal failed %s", err.Error())

--- a/output/output.go
+++ b/output/output.go
@@ -1,0 +1,8 @@
+package output
+
+type Type string
+
+const (
+	Type_ProgressBar = "progress-bar"
+	Type_Simple      = "simple"
+)


### PR DESCRIPTION
# Summary

When using `go-remove-slowly` on a remote server, it is often useful to redirect `go-remove-slowly`'s output to a file and then read the status of the command from that file using `tail -n1`. The current progress bar output _works_, more or less. However, I think we can improve it by making the output easier to understand and parse when redirected to another script.

**Sample output:**

```sh
$ dd if=/dev/urandom bs=4M count=10 of=40M
10+0 records in
10+0 records out
41943040 bytes transferred in 0.063223 secs (663414264 bytes/sec)

$ ./go-remove-slowly --output simple --size 1 --interval 1s 40M
Removing File: 40M
file: 40M       completion: 0.00%       remaining: 0s
file: 40M       completion: 2.50%       remaining: 39s
file: 40M       completion: 5.00%       remaining: 38s
file: 40M       completion: 7.50%       remaining: 37s
file: 40M       completion: 10.00%      remaining: 36s
file: 40M       completion: 12.50%      remaining: 35s
file: 40M       completion: 15.00%      remaining: 34s
file: 40M       completion: 17.50%      remaining: 33s
file: 40M       completion: 20.00%      remaining: 32s
file: 40M       completion: 22.50%      remaining: 31s
file: 40M       completion: 25.00%      remaining: 30s
file: 40M       completion: 27.50%      remaining: 29s
file: 40M       completion: 30.00%      remaining: 28s
file: 40M       completion: 32.50%      remaining: 27s
file: 40M       completion: 35.00%      remaining: 26s
file: 40M       completion: 37.50%      remaining: 25s
file: 40M       completion: 40.00%      remaining: 24s
file: 40M       completion: 42.50%      remaining: 23s
file: 40M       completion: 45.00%      remaining: 22s
file: 40M       completion: 47.50%      remaining: 21s
file: 40M       completion: 50.00%      remaining: 20s
file: 40M       completion: 52.50%      remaining: 19s
file: 40M       completion: 55.00%      remaining: 18s
file: 40M       completion: 57.50%      remaining: 17s
file: 40M       completion: 60.00%      remaining: 16s
file: 40M       completion: 62.50%      remaining: 15s
file: 40M       completion: 65.00%      remaining: 14s
file: 40M       completion: 67.50%      remaining: 13s
file: 40M       completion: 70.00%      remaining: 12s
file: 40M       completion: 72.50%      remaining: 11s
file: 40M       completion: 75.00%      remaining: 10s
file: 40M       completion: 77.50%      remaining: 9s
file: 40M       completion: 80.00%      remaining: 8s
file: 40M       completion: 82.50%      remaining: 7s
file: 40M       completion: 85.00%      remaining: 6s
file: 40M       completion: 87.50%      remaining: 5s
file: 40M       completion: 90.00%      remaining: 4s
file: 40M       completion: 92.50%      remaining: 3s
file: 40M       completion: 95.00%      remaining: 2s
file: 40M       completion: 97.50%      remaining: 1s
```